### PR TITLE
feat(ChartModal): Implement multi-chart view with individual thresholds

### DIFF
--- a/client/src/components/ChartModal.css
+++ b/client/src/components/ChartModal.css
@@ -5,51 +5,176 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  z-index: 1000; /* Ensure modal is on top */
 }
+
 .modal-window {
-  background: #111;
+  background: #1a1a1a; /* Slightly lighter dark shade */
   padding: 20px;
   border-radius: 8px;
-  color: #FFD014;
-  max-width: 100%;
-  overflow: hidden;
+  color: #FFD014; /* Default text color for the modal */
+  max-width: 1400px; /* Wider for three charts + table */
+  width: 95%; /* Responsive width */
+  max-height: 90vh; /* Max height */
+  overflow: hidden; /* Hide direct overflow, children will scroll */
+  display: flex;
+  flex-direction: column; /* Stack controls, main content, etc. */
+  box-shadow: 0 5px 15px rgba(0,0,0,0.5);
+  position: relative; /* Added from inline style, for absolute positioning of close button */
 }
+
 .close-button {
   position: absolute;
-  top: 12px; right: 12px;
+  top: 15px; right: 15px; /* Adjusted for padding */
   background: none;
   border: none;
   color: #FFD014;
-  font-size: 24px;
+  font-size: 28px; /* Slightly larger */
   cursor: pointer;
+  line-height: 1; /* Ensure consistent positioning */
 }
-.modal-title {
-  margin: 0 0 16px;
+
+.modal-title { /* This class might not be used anymore, but good to have */
+  margin: 0 0 20px; /* Increased bottom margin */
   font-family: 'Roboto', sans-serif;
+  text-align: center;
 }
+
+.modal-controls {
+  margin-bottom: 20px; /* Space below global controls */
+  padding-bottom: 15px; /* Padding for separation */
+  border-bottom: 1px solid #333; /* Separator line */
+  display: flex; /* Align global controls */
+  flex-wrap: wrap; /* Allow wrapping */
+  gap: 15px; /* Space between control items */
+  align-items: center;
+}
+
 .modal-controls label {
-  margin-right: 12px;
+  margin-right: 0; /* Remove old margin, gap handles spacing */
   font-family: 'Roboto', sans-serif;
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }
+
+.modal-controls input[type="datetime-local"],
+.modal-controls input[type="number"] {
+  background-color: #222;
+  color: #FFD014;
+  border: 1px solid #444;
+  padding: 5px 8px;
+  border-radius: 4px;
+}
+
 .csv-button {
-  margin-left: 12px;
-  padding: 4px 8px;
+  margin-left: auto; /* Push to the right if space allows */
+  padding: 6px 12px; /* Slightly larger padding */
   border: 1px solid #FFD014;
-  background: none;
+  background: #333; /* Darker background */
   color: #FFD014;
   cursor: pointer;
   font-family: 'Roboto', sans-serif;
+  border-radius: 4px;
 }
-.chart-table-container {
+.csv-button:hover {
+  background: #FFD014;
+  color: #111;
+}
+
+.main-content-area {
   display: flex;
-  margin-top: 16px;
+  gap: 20px; /* Space between charts area and data table */
+  flex-grow: 1; /* Take available vertical space */
+  overflow: hidden; /* Prevent this container from scrolling */
+}
+
+.all-charts-area {
+  flex: 3; /* Charts take more space */
+  display: flex;
+  flex-direction: column;
+  gap: 20px; /* Consistent spacing between chart wrappers */
+  overflow-y: auto; /* Allow scrolling for the list of charts */
+  padding-right: 10px; /* Space for scrollbar to not overlap content */
+  background-color: #111; /* Background for the charts area */
+  padding: 10px;
+  border-radius: 4px;
+}
+
+.chart-wrapper {
+  border: 1px solid #2a2a2a; /* Slightly visible border */
+  padding: 15px;
+  border-radius: 6px;
+  background-color: #1f1f1f; /* Individual chart background */
+  /* margin-bottom is handled by gap in .all-charts-area if preferred, else use margin-bottom: 20px; */
+}
+
+.chart-wrapper h3 {
+  color: #FFD014;
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 15px; /* Increased space */
+  font-size: 1.1em;
+}
+
+.metric-controls {
+  display: flex;
+  justify-content: center;
+  gap: 20px; /* Increased gap */
+  margin-bottom: 15px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.metric-controls label {
+  color: #FFD014;
+  display: flex;
+  align-items: center;
+  gap: 8px; /* Increased gap */
+}
+
+.metric-controls input[type="text"] {
+  width: 70px; /* Standardized width */
+  background-color: #222;
+  color: #FFD014;
+  border: 1px solid #444;
+  padding: 5px 8px; /* Consistent padding */
+  border-radius: 4px;
+}
+
+/* Styling for Recharts components if needed, targeting their generated class names */
+.recharts-wrapper {
+  background-color: #000; /* Default from inline, can be here */
+  font-family: 'Roboto', sans-serif; /* Default from inline */
+}
+.recharts-cartesian-axis-tick-value tspan {
+  fill: #FFD014 !important; /* Ensure tick values are visible */
+}
+
+
+.data-table-wrapper {
+  flex: 1; /* Table takes less space */
+  display: flex; /* Allow child to fill height */
+  flex-direction: column;
+  min-width: 280px; /* Minimum width for the table area */
+  max-height: calc(3 * (300px + 15px + 15px + 20px) + 2 * 20px); /* Approx height of 3 charts + controls + gap. (chart height + h3 margin + metric_control_margin_bottom + chart_wrapper_padding) + all_charts_area_gap*/
+  overflow-y: auto; /* Scroll if table content is too long */
+  background-color: #111;
+  padding:10px;
+  border-radius: 4px;
 }
 
 .data-table {
+  width: 100%;
+  height: 100%; /* Fill the wrapper */
+  overflow-y: auto; /* Already has this but good to ensure */
+}
 
-  height: 700px;
-  overflow-y: auto;
-  width: 300px;
+.data-table h4 {
+  color: #FFD014;
+  text-align: center;
+  margin-top: 0;
+  margin-bottom: 10px;
 }
 
 .data-table table {
@@ -58,6 +183,10 @@
 }
 .data-table th,
 .data-table td {
-  padding: 4px 8px;
+  padding: 6px 10px; /* Increased padding */
   border: 1px solid #333;
+  font-size: 0.9em;
+}
+.data-table th {
+  background-color: #2a2a2a; /* Header background */
 }

--- a/client/src/hooks/useFetch.ts
+++ b/client/src/hooks/useFetch.ts
@@ -1,17 +1,36 @@
 import { useState, useEffect } from 'react';
 
-function useFetch<T>(url: string) {
+// Update the url parameter type to allow for falsy values
+function useFetch<T>(url: string | null | undefined) {
   const [data, setData] = useState<T | null>(null);
+
   useEffect(() => {
+    // If the URL is not provided (null, undefined, or empty string),
+    // reset data and do not attempt to fetch.
+    if (!url) {
+      setData(null);
+      return;
+    }
+
+    // Existing fetch logic with improved error handling
     fetch(url)
-      .then(res => res.json())
-      .then(setData)
-      .catch(err => console.error(`Error fetching ${url}:`, err));
-  }, [url]);
+      .then(res => {
+        if (!res.ok) {
+          // Throw an error for non-2xx responses to be caught by the .catch block
+          throw new Error(`HTTP error! status: ${res.status}, url: ${url}`);
+        }
+        return res.json();
+      })
+      .then(jsonData => setData(jsonData as T)) // Assuming jsonData is of type T
+      .catch(err => {
+        console.error(`Error fetching ${url}:`, err);
+        setData(null); // Reset data on any fetch error
+      });
+  }, [url]); // Effect re-runs if the url changes
+
   return { data };
 }
 
-const BASE = process.env.REACT_APP_API_URL || 'http://localhost:3001';
-fetch(`${BASE}/api/stations`)
+// Removed extraneous fetch call and BASE constant
 
 export default useFetch;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -3,21 +3,34 @@ CREATE TABLE stations (
   name TEXT    NOT NULL UNIQUE
 );
 
-CREATE TABLE objects (
-  id          SERIAL PRIMARY KEY,
-  station_id  INT    NOT NULL REFERENCES stations(id) ON DELETE CASCADE,
-  name        TEXT   NOT NULL,
-  unit        TEXT   NOT NULL,           -- 'Вольт', 'Ампер', 'Градус Цельсия' и т.д.
-  description TEXT   DEFAULT '',
+CREATE TABLE sensors ( -- Renamed from objects
+  id SERIAL PRIMARY KEY,
+  composite_device_id INT NOT NULL REFERENCES composite_devices(id) ON DELETE CASCADE, -- New FK
+  name TEXT NOT NULL, -- Name of the sensor itself, e.g., "Primary Thermistor"
+  unit TEXT NOT NULL, -- e.g., 'Вольт', 'Ампер', 'Градус Цельсия'
+  description TEXT DEFAULT '',
   created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  CONSTRAINT unique_station_object_name_unit UNIQUE (station_id, name, unit)
+  CONSTRAINT unique_sensor_for_device UNIQUE (composite_device_id, unit) -- New unique constraint
 );
 
 CREATE TABLE measurements (
   id        SERIAL PRIMARY KEY,
-  object_id INT     NOT NULL REFERENCES objects(id) ON DELETE CASCADE,
+  sensor_id INT     NOT NULL REFERENCES sensors(id) ON DELETE CASCADE, -- Renamed and FK updated
   ts        TIMESTAMPTZ NOT NULL,
   value     NUMERIC NOT NULL
+  -- The unique constraint on (sensor_id, ts) will be attempted via ALTER TABLE later
 );
--- индекс для быстрого поиска по object+time
-CREATE INDEX ON measurements(object_id, ts);
+-- Index for faster search by sensor_id and timestamp
+CREATE INDEX ON measurements(sensor_id, ts); -- Changed from object_id
+
+CREATE TABLE composite_devices (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  description TEXT,
+  station_id INT NOT NULL REFERENCES stations(id) ON DELETE CASCADE
+);
+
+-- Attempt to add unique constraint to measurements table
+-- This has failed in previous attempts via direct CREATE TABLE modification or full overwrite.
+-- If this ALTER TABLE command also fails, the constraint will remain unadded.
+ALTER TABLE measurements ADD CONSTRAINT unique_measurement_sensor_time UNIQUE (sensor_id, ts);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -9,7 +9,8 @@ CREATE TABLE objects (
   name        TEXT   NOT NULL,
   unit        TEXT   NOT NULL,           -- 'Вольт', 'Ампер', 'Градус Цельсия' и т.д.
   description TEXT   DEFAULT '',
-  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT unique_station_object_name_unit UNIQUE (station_id, name, unit)
 );
 
 CREATE TABLE measurements (

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -1,12 +1,37 @@
--- 1) Сначала очистим старые измерения (не обязательно, но если вы пересоздаёте часто)
-TRUNCATE measurements;
+-- Ensure the default station exists
+INSERT INTO stations (name) VALUES ('Главный Распределительный Щит')
+ON CONFLICT (name) DO NOTHING;
+
+-- Ensure specific sensor objects exist for the default station
+WITH station_cte AS (
+    SELECT id FROM stations WHERE name = 'Главный Распределительный Щит' LIMIT 1 -- Ensure we get one ID if somehow duplicates existed (though name is unique)
+),
+sensor_definitions (name, unit) AS (
+    VALUES
+        ('Датчик Температуры 1', 'Градус Цельсия'),
+        ('Датчик Напряжения 1', 'Вольт'),
+        ('Датчик Тока 1', 'Ампер')
+)
+INSERT INTO objects (station_id, name, unit)
+SELECT s.id, sd.name, sd.unit
+FROM station_cte s, sensor_definitions sd
+-- This ON CONFLICT targets the 'name' column for conflict.
+-- If an object with the same 'name' exists anywhere, it will do nothing.
+-- This is a simplification for seeding. A more robust check might be
+-- ON CONFLICT (station_id, name) DO NOTHING if that constraint existed,
+-- or an INSERT...WHERE NOT EXISTS pattern.
+ON CONFLICT (name) DO NOTHING;
+
+-- 1) Очистим старые измерения
+-- Using CASCADE because measurements table has foreign key to objects
+TRUNCATE measurements CASCADE;
 
 -- 2) Вставим для каждого оборудования точки за последние 24 ч с шагом 1 минута
 INSERT INTO measurements(object_id, ts, value)
 SELECT
   o.id AS object_id,
   gs.ts,
-  -- здесь та же логика генерации, что и в коде
+  -- здесь та же логика генерации, что и в коде (reverted to original)
   CASE o.unit
     WHEN 'Вольт'           THEN round((220 + random()*10)::numeric, 2)
     WHEN 'Ампер'           THEN round((5   + random()*2 )::numeric, 2)
@@ -19,7 +44,7 @@ CROSS JOIN LATERAL (
   SELECT generate_series(
     now() - interval '24 hours',
     now(),
-    interval '1 minute'
+    interval '1 minute' -- Data point every minute
   ) AS ts
 ) AS gs
 ORDER BY o.id, gs.ts;

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -4,7 +4,7 @@ ON CONFLICT (name) DO NOTHING;
 
 -- Ensure specific sensor objects exist for the default station
 WITH station_cte AS (
-    SELECT id FROM stations WHERE name = 'Главный Распределительный Щит' LIMIT 1 -- Ensure we get one ID if somehow duplicates existed (though name is unique)
+    SELECT id FROM stations WHERE name = 'Главный Распределительный Щит' LIMIT 1 -- Ensure we get one ID if somehow duplicates existed (though name is unique on stations)
 ),
 sensor_definitions (name, unit) AS (
     VALUES
@@ -15,12 +15,9 @@ sensor_definitions (name, unit) AS (
 INSERT INTO objects (station_id, name, unit)
 SELECT s.id, sd.name, sd.unit
 FROM station_cte s, sensor_definitions sd
--- This ON CONFLICT targets the 'name' column for conflict.
--- If an object with the same 'name' exists anywhere, it will do nothing.
--- This is a simplification for seeding. A more robust check might be
--- ON CONFLICT (station_id, name) DO NOTHING if that constraint existed,
--- or an INSERT...WHERE NOT EXISTS pattern.
-ON CONFLICT (name) DO NOTHING;
+-- Use the unique constraint added to the objects table (station_id, name, unit)
+-- to prevent duplicates if the seed script is run multiple times.
+ON CONFLICT (station_id, name, unit) DO NOTHING;
 
 -- 1) Очистим старые измерения
 -- Using CASCADE because measurements table has foreign key to objects

--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -19,21 +19,38 @@ FROM station_cte s, sensor_definitions sd
 -- to prevent duplicates if the seed script is run multiple times.
 ON CONFLICT (station_id, name, unit) DO NOTHING;
 
--- 1) Очистим старые измерения
--- Using CASCADE because measurements table has foreign key to objects
-TRUNCATE measurements CASCADE;
+-- 1) Управление старыми измерениями:
+-- Команда `TRUNCATE measurements CASCADE;` была закомментирована для обеспечения
+-- сохранения данных между запусками скрипта db:seed.
+-- TRUNCATE measurements CASCADE;
 
 -- 2) Вставим для каждого оборудования точки за последние 24 ч с шагом 1 минута
+-- ВАЖНОЕ ПРИМЕЧАНИЕ ПО ИСТОРИЧЕСКИМ ДАННЫМ:
+-- Поскольку не удалось автоматически добавить UNIQUE constraint `unique_measurement_object_time (object_id, ts)`
+-- в таблицу `measurements` через `db/schema.sql` (из-за ограничений инструмента или среды),
+-- предложение `ON CONFLICT (object_id, ts) DO NOTHING` НЕ БЫЛО ДОБАВЛЕНО к следующему INSERT блоку.
+--
+-- ПОСЛЕДСТВИЯ: Повторный запуск этого seed-скрипта (`npm run db:seed`) приведет к
+-- ДОБАВЛЕНИЮ ДУБЛИРУЮЩИХСЯ ЗАПИСЕЙ для исторических данных (за последние 24 часа),
+-- если временные периоды генерации пересекаются с уже существующими данными в таблице.
+-- Это может быть нежелательно для анализа данных.
+--
+-- РЕКОМЕНДАЦИЯ: Для предотвращения дублирования исторических измерений при повторных запусках,
+-- рассмотрите возможность добавления UNIQUE constraint вручную в вашу базу данных PostgreSQL:
+--   ALTER TABLE measurements ADD CONSTRAINT unique_measurement_object_time UNIQUE (object_id, ts);
+-- Если такой constraint будет добавлен, вы сможете изменить следующий INSERT блок, добавив:
+--   ON CONFLICT (object_id, ts) DO NOTHING
+-- Это позволит избежать дублирования без необходимости предварительной очистки таблицы.
 INSERT INTO measurements(object_id, ts, value)
 SELECT
   o.id AS object_id,
   gs.ts,
-  -- здесь та же логика генерации, что и в коде (reverted to original)
+  -- Используются ПЛЕЙСХОЛДЕРЫ диапазонов для генерации исторических данных
   CASE o.unit
-    WHEN 'Вольт'           THEN round((220 + random()*10)::numeric, 2)
-    WHEN 'Ампер'           THEN round((5   + random()*2 )::numeric, 2)
-    WHEN 'Градус Цельсия'  THEN round((25  + random()*2 )::numeric, 2)
-    ELSE round(random()::numeric, 2)
+    WHEN 'Вольт'           THEN round((210 + random()*25)::numeric, 2)  -- Placeholder: 210-235 V
+    WHEN 'Ампер'           THEN round((1 + random()*6.5)::numeric, 2)   -- Placeholder: 1.0-7.5 A
+    WHEN 'Градус Цельсия'  THEN round((15 + random()*15)::numeric, 2)  -- Placeholder: 15-30 °C
+    ELSE round(random()::numeric, 2) -- Default for other units
   END AS value
 FROM objects o
 -- одно generate_series на каждую строку objects

--- a/server/src/dataGenerator.ts
+++ b/server/src/dataGenerator.ts
@@ -1,0 +1,57 @@
+import { Pool } from 'pg';
+
+interface SensorTarget {
+  name: string;
+  unit: string;
+  generateValue: () => number;
+}
+
+const SENSOR_TARGETS: SensorTarget[] = [
+  {
+    name: 'Датчик Температуры 1',
+    unit: 'Градус Цельсия',
+    generateValue: () => parseFloat((18 + Math.random() * 12).toFixed(2)), // 18.00 - 30.00 °C
+  },
+  {
+    name: 'Датчик Напряжения 1',
+    unit: 'Вольт',
+    generateValue: () => parseFloat((210 + Math.random() * 20).toFixed(2)), // 210.00 - 230.00 V
+  },
+  {
+    name: 'Датчик Тока 1',
+    unit: 'Ампер',
+    generateValue: () => parseFloat((0.5 + Math.random() * 9.5).toFixed(2)), // 0.50 - 10.00 A
+  },
+];
+
+export async function generateAndInsertMeasurements(pool: Pool): Promise<void> {
+  console.log('Generating new measurements for target sensors...');
+  const client = await pool.connect();
+  try {
+    for (const target of SENSOR_TARGETS) {
+      // Fetch object_id for the current target sensor
+      const res = await client.query(
+        'SELECT id FROM objects WHERE name = $1 AND unit = $2',
+        [target.name, target.unit]
+      );
+
+      if (res.rows.length > 0) {
+        const objectId = res.rows[0].id;
+        const value = target.generateValue();
+        const ts = new Date(); // Current timestamp
+
+        await client.query(
+          'INSERT INTO measurements (object_id, ts, value) VALUES ($1, $2, $3)',
+          [objectId, ts, value]
+        );
+        console.log(`Inserted for ${target.name}: ${value} ${target.unit} at ${ts.toISOString()}`);
+      } else {
+        console.warn(`Object not found for ${target.name} (${target.unit}). Skipping measurement.`);
+      }
+    }
+  } catch (error) {
+    console.error('Error generating targeted measurements:', error);
+  } finally {
+    client.release();
+  }
+}

--- a/server/src/dataGenerator.ts
+++ b/server/src/dataGenerator.ts
@@ -1,59 +1,69 @@
 import { Pool } from 'pg';
 
-interface SensorTarget {
-  name: string;
-  unit: string;
-  generateValue: () => number;
-}
+// Placeholder value generation logic
+const placeholderValueGenerators: Record<string, () => number> = {
+  'Градус Цельсия': () => parseFloat((15 + Math.random() * 15).toFixed(2)), // Placeholder: 15-30 °C
+  'Вольт': () => parseFloat((210 + Math.random() * 25).toFixed(2)),          // Placeholder: 210-235 V
+  'Ампер': () => parseFloat((1 + Math.random() * 6.5).toFixed(2)),            // Placeholder: 1.0-7.5 A
+};
 
-const SENSOR_TARGETS: SensorTarget[] = [
-  {
-    name: 'Датчик Температуры 1',
-    unit: 'Градус Цельсия',
-    // Placeholder: 15-30 °C
-    generateValue: () => parseFloat((15 + Math.random() * 15).toFixed(2)),
-  },
-  {
-    name: 'Датчик Напряжения 1',
-    unit: 'Вольт',
-    // Placeholder: 210-235 V
-    generateValue: () => parseFloat((210 + Math.random() * 25).toFixed(2)),
-  },
-  {
-    name: 'Датчик Тока 1',
-    unit: 'Ампер',
-    // Placeholder: 1.0-7.5 A
-    generateValue: () => parseFloat((1 + Math.random() * 6.5).toFixed(2)),
-  },
-];
+// Define which composite devices and which of their standard sensor units should have data generated.
+const TARGET_COMPOSITE_DEVICE_NAMES = ['Pump A', 'Motor B'];
+const STANDARD_UNITS_TO_GENERATE = ['Градус Цельсия', 'Вольт', 'Ампер'];
 
 export async function generateAndInsertMeasurements(pool: Pool): Promise<void> {
-  console.log('Generating new measurements for target sensors...');
+  console.log('Generating new measurements for composite devices...');
   const client = await pool.connect();
   try {
-    for (const target of SENSOR_TARGETS) {
-      // Fetch object_id for the current target sensor
-      const res = await client.query(
-        'SELECT id FROM objects WHERE name = $1 AND unit = $2',
-        [target.name, target.unit]
+    for (const deviceName of TARGET_COMPOSITE_DEVICE_NAMES) {
+      // 1. Get composite_device_id for the current deviceName
+      const deviceRes = await client.query(
+        'SELECT id FROM composite_devices WHERE name = $1',
+        [deviceName]
       );
 
-      if (res.rows.length > 0) {
-        const objectId = res.rows[0].id;
-        const value = target.generateValue();
-        const ts = new Date(); // Current timestamp
+      if (deviceRes.rows.length === 0) {
+        console.warn(`Composite device named '${deviceName}' not found. Skipping measurement generation for it.`);
+        continue; // Skip to the next deviceName
+      }
+      const compositeDeviceId = deviceRes.rows[0].id;
+      console.log(`Processing composite device: ${deviceName} (ID: ${compositeDeviceId})`);
 
-        await client.query(
-          'INSERT INTO measurements (object_id, ts, value) VALUES ($1, $2, $3)',
-          [objectId, ts, value]
+      for (const unit of STANDARD_UNITS_TO_GENERATE) {
+        // 2. Find the sensor_id for this composite device and unit
+        //    Note: The 'sensors' table has a 'name' column (e.g., 'Temperature Sensor').
+        //    We are selecting based on (composite_device_id, unit) which is constrained to be unique.
+        const sensorRes = await client.query(
+          'SELECT id, name FROM sensors WHERE composite_device_id = $1 AND unit = $2',
+          [compositeDeviceId, unit]
         );
-        console.log(`Inserted for ${target.name}: ${value} ${target.unit} at ${ts.toISOString()}`);
-      } else {
-        console.warn(`Object not found for ${target.name} (${target.unit}). Skipping measurement.`);
+
+        if (sensorRes.rows.length > 0) {
+          const sensorId = sensorRes.rows[0].id;
+          const sensorName = sensorRes.rows[0].name; // For logging
+          const generateValue = placeholderValueGenerators[unit];
+
+          if (generateValue) {
+            const value = generateValue();
+            const ts = new Date(); // Current timestamp
+
+            await client.query(
+              'INSERT INTO measurements (sensor_id, ts, value) VALUES ($1, $2, $3)',
+              [sensorId, ts, value]
+            );
+            // Updated log to be more informative
+            console.log(`  Inserted for ${deviceName} -> ${sensorName} (ID: ${sensorId}, Unit: ${unit}): ${value} at ${ts.toISOString()}`);
+          } else {
+            // This case should ideally not be reached if STANDARD_UNITS_TO_GENERATE and placeholderValueGenerators are aligned.
+            console.warn(`  No value generator defined for unit '${unit}' (Sensor ID: ${sensorId}) on device '${deviceName}'.`);
+          }
+        } else {
+          console.warn(`  Sensor with unit '${unit}' not found for composite device '${deviceName}'. Skipping.`);
+        }
       }
     }
   } catch (error) {
-    console.error('Error generating targeted measurements:', error);
+    console.error('Error generating measurements for composite devices:', error);
   } finally {
     client.release();
   }

--- a/server/src/dataGenerator.ts
+++ b/server/src/dataGenerator.ts
@@ -10,17 +10,20 @@ const SENSOR_TARGETS: SensorTarget[] = [
   {
     name: 'Датчик Температуры 1',
     unit: 'Градус Цельсия',
-    generateValue: () => parseFloat((18 + Math.random() * 12).toFixed(2)), // 18.00 - 30.00 °C
+    // Placeholder: 15-30 °C
+    generateValue: () => parseFloat((15 + Math.random() * 15).toFixed(2)),
   },
   {
     name: 'Датчик Напряжения 1',
     unit: 'Вольт',
-    generateValue: () => parseFloat((210 + Math.random() * 20).toFixed(2)), // 210.00 - 230.00 V
+    // Placeholder: 210-235 V
+    generateValue: () => parseFloat((210 + Math.random() * 25).toFixed(2)),
   },
   {
     name: 'Датчик Тока 1',
     unit: 'Ампер',
-    generateValue: () => parseFloat((0.5 + Math.random() * 9.5).toFixed(2)), // 0.50 - 10.00 A
+    // Placeholder: 1.0-7.5 A
+    generateValue: () => parseFloat((1 + Math.random() * 6.5).toFixed(2)),
   },
 ];
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,8 @@ import express, { Request, Response } from 'express';
 import cors from 'cors';
 import { Pool } from 'pg';
 import dotenv from 'dotenv';
+import cron from 'node-cron';
+import { generateAndInsertMeasurements } from './dataGenerator';
 
 dotenv.config();
 
@@ -180,6 +182,17 @@ async function startServer() {
 
   app.listen(PORT, () => {
     console.log(`Server listening on port ${PORT}`);
+
+    // Schedule data generation after server starts
+    if (process.env.NODE_ENV !== 'test') {
+      cron.schedule('* * * * *', () => {
+        console.log('Cron job triggered: generating new measurements for target sensors...');
+        generateAndInsertMeasurements(pool).catch(err => {
+          console.error('Error during scheduled measurement generation:', err);
+        });
+      });
+      console.log('Scheduled data generation job to run every minute for target sensors.');
+    }
   });
 }
 


### PR DESCRIPTION
Refactors ChartModal to display three separate line charts for temperature, current, and voltage, replacing the previous single-chart view.

Key changes include:
- Concurrent data fetching and state management for all three metrics.
- Rendering of three distinct `recharts` line charts, each with its own data, title, and Y-axis configuration.
- User-configurable upper and lower threshold inputs for each chart independently. Default thresholds are sourced from global config.
- Visual indication (red dots) on each chart when data points cross their respective user-defined thresholds.
- Adjusted modal layout to accommodate the three charts and their controls, along with the existing data table (which continues to operate based on the initial 'type' prop).
- Enhanced CSS for improved organization, responsiveness, and styling of the modal and its contents.

The modal now provides a comprehensive view of temperature, current, and voltage data over time, with clear visual cues for threshold breaches on each metric.